### PR TITLE
Allow LAN dashboard access during developer onboarding

### DIFF
--- a/scripts/onboard.sh
+++ b/scripts/onboard.sh
@@ -104,8 +104,8 @@ set_env_value() {
 
 validate_bind_address() {
   case "$1" in
-    ""|0.0.0.0|::|*[!A-Za-z0-9._:-]*)
-      die "dashboard bind address must be one private address without whitespace or shell syntax"
+    ""|::|*[!A-Za-z0-9._:-]*)
+      die "dashboard bind address must be one address without whitespace or shell syntax"
       ;;
   esac
 }
@@ -211,14 +211,18 @@ if confirm "Enable the private dashboard on this device?" yes; then
   fi
   if [ -n "$TAILSCALE_IP" ]; then
     echo "Tailscale address candidate: $TAILSCALE_IP"
-    printf 'Dashboard bind address [%s]: ' "$TAILSCALE_IP"
+    printf 'Dashboard bind address [%s] (use 0.0.0.0 for LAN access): ' "$TAILSCALE_IP"
     IFS= read -r DASH_BIND || exit 1
     DASH_BIND=${DASH_BIND:-$TAILSCALE_IP}
   else
-    printf 'Dashboard bind address: '
+    printf 'Dashboard bind address [0.0.0.0 for LAN access]: '
     IFS= read -r DASH_BIND || exit 1
+    DASH_BIND=${DASH_BIND:-0.0.0.0}
   fi
   validate_bind_address "$DASH_BIND"
+  if [ "$DASH_BIND" = 0.0.0.0 ]; then
+    echo "Warning: the dashboard has no login and will be reachable on every connected network."
+  fi
   set_env_value MSGBOX_DASH_BIND "$DASH_BIND"
 else
   DASHBOARD=0


### PR DESCRIPTION
## Summary

This change adds a local-network option to the standalone developer onboarding flow.

- Keeps a detected Tailscale IP as the recommended default.
- Allows `0.0.0.0` to expose the dashboard through any Pi network interface.
- Defaults to `0.0.0.0` when Tailscale is unavailable.
- Warns that LAN mode exposes the unauthenticated dashboard on every connected network.
- Continues accepting a specific bind address when required.

No dashboard server behavior changed; it already supports binding to `0.0.0.0`.

## Validation

- `make check`
- 159 tests passed
- Shell syntax, ShellCheck, Ruff, and Biome passed
- `git diff --check`