### PR TITLE
Fix macOS provisioning paths

### DIFF
--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -37,6 +37,9 @@ trap cleanup EXIT
 trap 'exit 1' HUP INT TERM
 
 echo "Copying installation files to $TARGET:$REMOTE_SOURCE"
+(
+cd "$REPO_DIR"
+REPO_DIR=.
 rsync -azR \
   "$REPO_DIR/./config/env.example" \
   "$REPO_DIR/./config/onboarding/" \
@@ -80,6 +83,7 @@ rsync -azR \
   "$REPO_DIR/./messagebox/onboarding/static/styles.css" \
   "$REPO_DIR/./systemd/" \
   "$TARGET:$REMOTE_SOURCE/"
+)
 
 echo "Running setup on $TARGET"
 ssh -t "$TARGET" \

--- a/tests/test_provision.py
+++ b/tests/test_provision.py
@@ -57,7 +57,7 @@ for arg in "$@"; do printf '%s\\0' "$arg"; done >"$RSYNC_LOG"
         )
         return subprocess.run(
             [str(PROVISION), target],
-            cwd=ROOT,
+            cwd=self.root,
             env=env,
             text=True,
             capture_output=True,
@@ -73,6 +73,10 @@ for arg in "$@"; do printf '%s\\0' "$arg"; done >"$RSYNC_LOG"
         self.assertEqual(
             rsync_args[-1],
             "admin@message-box.local:/tmp/messagebox-provision.test/",
+        )
+        self.assertTrue(
+            all(not os.path.isabs(path) for path in rsync_args[1:-1]),
+            rsync_args,
         )
 
         staged_paths = {


### PR DESCRIPTION
## Outcome

Make provisioning work with the OpenRsync version bundled with macOS by sending repository-relative source paths while preserving the existing `rsync -R` staging layout.

## What changed

- Run rsync from the repository root and use relative source paths.
- Run the provisioning contract test from an unrelated working directory.
- Assert that every staged source argument is relative.

## Non-goals

- No changes to the installer allowlist.
- No changes to Raspberry Pi runtime, onboarding, services, or credentials.
- No deployment or service restart.

## Evidence

- Reproduced the original failure on a clean Raspberry Pi card from macOS: absolute `/./` paths were recreated under the remote staging directory and `scripts/setup.sh` was not found.
- Provisioning completed successfully on the physical Pi with this fix.
- Python and shell syntax passed.
- Ruff passed.
- ShellCheck passed.
- Biome 2.5.9 passed.
- All 184 unit tests passed.
- `git diff --check` passed; a focused secret and identifier scan found no matches.

## Risk and rollback

Risk is limited to provisioning source-path construction. The explicit allowlist and remote cleanup behavior are unchanged.

Roll back by reverting this commit. Linux rsync behavior returns to the previous absolute-path form, while macOS OpenRsync provisioning will fail as before.
