### PR TITLE
Detect audio devices during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v
 
 syntax:
-	PYTHONPYCACHEPREFIX=/tmp/messagebox-pycache python3 -m compileall -q messagebox tests
+	PYTHONPYCACHEPREFIX=/tmp/messagebox-pycache python3 -m compileall -q messagebox tests scripts/install/audio_config.py
 	for file in scripts/*.sh scripts/commands/* scripts/dev/onboard.sh scripts/dev/hardware-test.sh scripts/dev/reprovision.sh scripts/install/*.sh; do sh -n "$$file"; done
 	sh -n scripts/messageboxctl
 	bash -n messagebox/syncloop.sh
@@ -12,7 +12,7 @@ syntax:
 lint: lint-python lint-shell lint-frontend
 
 lint-python:
-	uvx --from ruff==0.16.3 ruff check --target-version=py313 --select=E4,E7,E9,F messagebox tests
+	uvx --from ruff==0.16.3 ruff check --target-version=py313 --select=E4,E7,E9,F messagebox tests scripts/install/audio_config.py
 
 lint-shell:
 	uvx --from shellcheck-py==0.11.0.1 shellcheck --exclude=SC1007,SC1091,SC2029 scripts/*.sh scripts/commands/* scripts/dev/onboard.sh scripts/dev/hardware-test.sh scripts/dev/reprovision.sh scripts/install/*.sh scripts/messageboxctl messagebox/syncloop.sh

--- a/config/env.example
+++ b/config/env.example
@@ -2,7 +2,8 @@
 # Contact identity and chat access are stored privately in contacts.json. Use
 # messagebox-contact to add, remove, and enroll contacts and NFC cards.
 
-# ALSA devices by card NAME (numbers shuffle between boots)
+# ALSA devices by card NAME (numbers shuffle between boots). Fresh setup
+# replaces the microphone and speaker values with detected ALSA devices.
 MSGBOX_MIC_DEV=plughw:CARD=mic,DEV=0
 MSGBOX_SPK_DEV=plughw:CARD=Device,DEV=0
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,9 +26,11 @@ not overwrite a working device without a tested backup.
    Neither method transfers device runtime state, pairs WhatsApp, or starts
    Message Box services.
 
-   Setup installs the supported hardware defaults as `/etc/messagebox/env` only
-   when that file does not already exist. Later updates preserve operator
-   customization.
+   Connect the microphone and USB speaker before running setup. On a fresh
+   installation, setup selects the lowest-numbered ALSA capture device and USB
+   playback device, then records their card names in `/etc/messagebox/env`;
+   setup fails if either is unavailable. Later updates preserve the existing
+   file and operator customization.
 
    The Pi needs internet access during setup. See
    [Internet access for a fresh card](developer-onboarding.md#internet-access-for-a-fresh-card).

--- a/messagebox/onboarding/nfc.py
+++ b/messagebox/onboarding/nfc.py
@@ -141,9 +141,9 @@ class TonePlayer:
             sequence = [(1760, 0.08)] if kind == "read" else [(1320, 0.08), (1760, 0.11)]
             self._write_tone(path, sequence)
             os.chmod(path, 0o600)
-        card = os.environ.get("MSGBOX_SPEAKER_CARD", "Device")
+        device = os.environ.get("MSGBOX_SPK_DEV", "plughw:CARD=Device,DEV=0")
         self.run(
-            ["aplay", "-q", "-D", f"plughw:CARD={card}", os.fspath(path)],
+            ["aplay", "-q", "-D", device, os.fspath(path)],
             check=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,

--- a/scripts/install/audio_config.py
+++ b/scripts/install/audio_config.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Render initial Message Box configuration for attached audio devices."""
+
+import re
+import sys
+from pathlib import Path
+
+
+CAPTURE_NODE = re.compile(r"pcmC([0-9]+)D([0-9]+)c\Z")
+PLAYBACK_NODE = re.compile(r"pcmC([0-9]+)D([0-9]+)p\Z")
+CARD_ID = re.compile(r"[A-Za-z0-9_-]+\Z")
+USB_ID = re.compile(r"[0-9A-Fa-f]{4}\Z")
+
+
+class AudioConfigError(RuntimeError):
+    pass
+
+
+def _card_id(sound_root, card_number):
+    try:
+        card_id = (sound_root / f"card{card_number}" / "id").read_text(
+            encoding="ascii"
+        ).strip()
+    except (OSError, UnicodeError):
+        return None
+    return card_id if CARD_ID.fullmatch(card_id) else None
+
+
+def _is_usb(card_path):
+    try:
+        device_path = (card_path / "device").resolve(strict=True)
+    except (OSError, RuntimeError):
+        return False
+    for path in (device_path, *device_path.parents):
+        try:
+            vendor = (path / "idVendor").read_text(encoding="ascii").strip()
+            product = (path / "idProduct").read_text(encoding="ascii").strip()
+        except (OSError, UnicodeError):
+            continue
+        return bool(USB_ID.fullmatch(vendor) and USB_ID.fullmatch(product))
+    return False
+
+
+def detect_microphone(sound_root=Path("/sys/class/sound")):
+    candidates = []
+    capture_found = False
+    for capture_path in sound_root.glob("pcmC*D*c"):
+        match = CAPTURE_NODE.fullmatch(capture_path.name)
+        if match is None:
+            continue
+        capture_found = True
+        card_number, device_number = (int(value) for value in match.groups())
+        card_id = _card_id(sound_root, card_number)
+        if card_id is not None:
+            candidates.append((card_number, device_number, card_id))
+
+    if not candidates:
+        if capture_found:
+            raise AudioConfigError("could not read a valid ALSA capture card ID")
+        raise AudioConfigError("no ALSA capture device detected; connect a microphone")
+
+    _, device_number, card_id = min(candidates)
+    return card_id, f"plughw:CARD={card_id},DEV={device_number}"
+
+
+def detect_speaker(sound_root=Path("/sys/class/sound")):
+    candidates = []
+    for playback_path in sound_root.glob("pcmC*D*p"):
+        match = PLAYBACK_NODE.fullmatch(playback_path.name)
+        if match is None:
+            continue
+        card_number, device_number = (int(value) for value in match.groups())
+        card_path = sound_root / f"card{card_number}"
+        card_id = _card_id(sound_root, card_number)
+        if card_id is not None and _is_usb(card_path):
+            candidates.append((card_number, device_number, card_id))
+
+    if not candidates:
+        raise AudioConfigError(
+            "no USB ALSA playback device detected; connect a USB speaker"
+        )
+
+    _, device_number, card_id = min(candidates)
+    return card_id, f"plughw:CARD={card_id},DEV={device_number}"
+
+
+def render_environment(
+    template,
+    microphone_card,
+    microphone_device,
+    speaker_card,
+    speaker_device,
+):
+    replacements = {
+        "MSGBOX_MIC_DEV": microphone_device,
+        "MSGBOX_SPK_DEV": speaker_device,
+        "MSGBOX_MIC_CARD": microphone_card,
+        "MSGBOX_SPEAKER_CARD": speaker_card,
+    }
+    counts = dict.fromkeys(replacements, 0)
+    rendered = []
+    for line in template.splitlines():
+        key = line.split("=", 1)[0]
+        if key in replacements:
+            counts[key] += 1
+            line = f"{key}={replacements[key]}"
+        rendered.append(line)
+
+    invalid = [key for key, count in counts.items() if count != 1]
+    if invalid:
+        raise AudioConfigError(
+            "configuration template must define each audio setting exactly once"
+        )
+    return "\n".join(rendered) + "\n"
+
+
+def main(argv=None):
+    arguments = sys.argv[1:] if argv is None else argv
+    if len(arguments) != 1:
+        print("Usage: audio_config.py ENV_TEMPLATE", file=sys.stderr)
+        return 2
+    try:
+        microphone_card, microphone_device = detect_microphone()
+        speaker_card, speaker_device = detect_speaker()
+        template = Path(arguments[0]).read_text(encoding="utf-8")
+        sys.stdout.write(
+            render_environment(
+                template,
+                microphone_card,
+                microphone_device,
+                speaker_card,
+                speaker_device,
+            )
+        )
+    except (AudioConfigError, OSError, UnicodeError) as exc:
+        print(f"audio setup: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -53,6 +53,7 @@ for path in \
   config/onboarding/comitup-dbus.conf \
   config/onboarding/firewall.nft \
   scripts/install/comitup.sh \
+  scripts/install/audio_config.py \
   scripts/install/nfc.sh \
   scripts/install/wacli.sh \
   scripts/commands/messagebox-comitup-state \
@@ -138,11 +139,6 @@ if [ -L "$APP_DIR" ] || { [ -e "$APP_DIR" ] && [ ! -d "$APP_DIR" ]; }; then
   echo "Cannot install into non-directory application path: $APP_DIR" >&2
   exit 1
 fi
-if [ -L "$CONFIG_DIR/env" ] || { [ -e "$CONFIG_DIR/env" ] && [ ! -f "$CONFIG_DIR/env" ]; }; then
-  echo "Cannot use non-regular runtime configuration: $CONFIG_DIR/env" >&2
-  exit 1
-fi
-
 if sudo test -e "$ONBOARDING_CONFIG_DIR/enabled"; then
   echo "Refusing to update while Wi-Fi onboarding is armed." >&2
   exit 1
@@ -170,6 +166,31 @@ for unit in \
     exit 1
   fi
 done
+
+GENERATED_ENV=
+CONFIG_STAGE=
+cleanup() {
+  if [ -n "$GENERATED_ENV" ]; then
+    rm -f "$GENERATED_ENV"
+  fi
+  if [ -n "$CONFIG_STAGE" ]; then
+    sudo rm -f "$CONFIG_STAGE"
+  fi
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+if sudo test -L "$CONFIG_DIR/env" || {
+  sudo test -e "$CONFIG_DIR/env" && ! sudo test -f "$CONFIG_DIR/env"
+}; then
+  echo "Cannot use non-regular runtime configuration: $CONFIG_DIR/env" >&2
+  exit 1
+fi
+if ! sudo test -e "$CONFIG_DIR/env"; then
+  GENERATED_ENV=$(mktemp)
+  /usr/bin/python3 "$SCRIPT_DIR/install/audio_config.py" \
+    "$REPO_DIR/config/env.example" >"$GENERATED_ENV"
+fi
 
 if account=$(getent passwd "$SERVICE_USER"); then
   account_home=$(printf '%s\n' "$account" | cut -d: -f6)
@@ -287,9 +308,18 @@ done
 
 sudo install -o root -g "$SERVICE_GROUP" -m 0640 \
   "$REPO_DIR/config/env.example" "$CONFIG_DIR/env.example"
-if ! sudo test -e "$CONFIG_DIR/env"; then
+if [ -n "$GENERATED_ENV" ]; then
+  CONFIG_STAGE=$(sudo mktemp "$CONFIG_DIR/.env.XXXXXX")
   sudo install -o root -g "$SERVICE_GROUP" -m 0640 \
-    "$REPO_DIR/config/env.example" "$CONFIG_DIR/env"
+    "$GENERATED_ENV" "$CONFIG_STAGE"
+  if ! sudo ln -T "$CONFIG_STAGE" "$CONFIG_DIR/env"; then
+    echo "Runtime configuration appeared during setup: $CONFIG_DIR/env" >&2
+    exit 1
+  fi
+  sudo rm -f "$CONFIG_STAGE"
+  CONFIG_STAGE=
+  rm -f "$GENERATED_ENV"
+  GENERATED_ENV=
 fi
 
 (cd "$APP_DIR" && sudo /usr/bin/python3 -m messagebox.make_ringtones)

--- a/systemd/onboarding/messagebox-onboarding-nfc.service
+++ b/systemd/onboarding/messagebox-onboarding-nfc.service
@@ -14,7 +14,7 @@ SupplementaryGroups=messagebox i2c gpio audio
 WorkingDirectory=/opt/messagebox
 Environment=HOME=/var/lib/messagebox
 Environment=MSGBOX_NFC_ONBOARDING_SOCKET_GROUP=messagebox-onboarding
-Environment=MSGBOX_SPEAKER_CARD=Device
+EnvironmentFile=/etc/messagebox/env
 UMask=0077
 RuntimeDirectory=messagebox-onboarding-nfc
 RuntimeDirectoryMode=0750

--- a/tests/test_audio_config.py
+++ b/tests/test_audio_config.py
@@ -1,0 +1,119 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "install" / "audio_config.py"
+SPEC = importlib.util.spec_from_file_location("audio_config", HELPER)
+audio_config = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audio_config)
+
+
+class AudioConfigTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.sound_root = self.root / "class" / "sound"
+        self.sound_root.mkdir(parents=True)
+
+    def add_device(self, card, device, card_id, kind, *, usb=False):
+        bus_path = self.root / "devices" / f"bus-{card}"
+        interface = bus_path / f"{card}:1.0"
+        card_path = interface / "sound" / f"card{card}"
+        card_path.mkdir(parents=True, exist_ok=True)
+        (card_path / "id").write_text(f"{card_id}\n", encoding="ascii")
+        device_link = card_path / "device"
+        if not device_link.exists():
+            device_link.symlink_to(interface, target_is_directory=True)
+        if usb:
+            (bus_path / "idVendor").write_text("1234\n", encoding="ascii")
+            (bus_path / "idProduct").write_text("5678\n", encoding="ascii")
+
+        card_link = self.sound_root / f"card{card}"
+        if not card_link.exists():
+            card_link.symlink_to(card_path, target_is_directory=True)
+        pcm_path = card_path / f"pcmC{card}D{device}{kind}"
+        pcm_path.touch()
+        (self.sound_root / pcm_path.name).symlink_to(pcm_path)
+
+    def add_capture(self, card, device, card_id):
+        self.add_device(card, device, card_id, "c")
+
+    def add_playback(self, card, device, card_id, *, usb=False):
+        self.add_device(card, device, card_id, "p", usb=usb)
+
+    def test_returns_card_and_device_config_values(self):
+        self.add_capture(4, 0, "microphone")
+
+        self.assertEqual(
+            audio_config.detect_microphone(self.sound_root),
+            ("microphone", "plughw:CARD=microphone,DEV=0"),
+        )
+
+    def test_fallback_uses_lowest_numeric_card_and_device(self):
+        self.add_capture(10, 0, "later")
+        self.add_capture(2, 3, "first")
+        self.add_capture(2, 1, "first")
+
+        self.assertEqual(
+            audio_config.detect_microphone(self.sound_root),
+            ("first", "plughw:CARD=first,DEV=1"),
+        )
+
+    def test_no_capture_device_fails_clearly(self):
+        with self.assertRaisesRegex(
+            audio_config.AudioConfigError, "connect a microphone"
+        ):
+            audio_config.detect_microphone(self.sound_root)
+
+    def test_speaker_uses_lowest_usb_playback_and_ignores_hdmi(self):
+        self.add_playback(0, 0, "hdmi")
+        self.add_playback(10, 0, "later", usb=True)
+        self.add_playback(2, 1, "speaker", usb=True)
+
+        self.assertEqual(
+            audio_config.detect_speaker(self.sound_root),
+            ("speaker", "plughw:CARD=speaker,DEV=1"),
+        )
+
+    def test_no_usb_playback_device_fails_clearly(self):
+        self.add_playback(0, 0, "hdmi")
+
+        with self.assertRaisesRegex(audio_config.AudioConfigError, "USB speaker"):
+            audio_config.detect_speaker(self.sound_root)
+
+    def test_renders_audio_settings_and_preserves_mixer_volume(self):
+        template = (ROOT / "config" / "env.example").read_text(encoding="utf-8")
+
+        rendered = audio_config.render_environment(
+            template,
+            "microphone",
+            "plughw:CARD=microphone,DEV=0",
+            "speaker",
+            "plughw:CARD=speaker,DEV=1",
+        )
+
+        self.assertIn("MSGBOX_MIC_DEV=plughw:CARD=microphone,DEV=0\n", rendered)
+        self.assertIn("MSGBOX_MIC_CARD=microphone\n", rendered)
+        self.assertIn("MSGBOX_SPK_DEV=plughw:CARD=speaker,DEV=1\n", rendered)
+        self.assertIn("MSGBOX_SPEAKER_CARD=speaker\n", rendered)
+        self.assertIn("MSGBOX_SPEAKER_VOLUME=50%\n", rendered)
+
+    def test_template_requires_each_audio_setting_once(self):
+        with self.assertRaisesRegex(
+            audio_config.AudioConfigError, "exactly once"
+        ):
+            audio_config.render_environment(
+                "MSGBOX_MIC_DEV=one\nMSGBOX_MIC_DEV=two\n",
+                "microphone",
+                "plughw:CARD=microphone,DEV=0",
+                "speaker",
+                "plughw:CARD=speaker,DEV=0",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nfc_pairing_onboarding.py
+++ b/tests/test_nfc_pairing_onboarding.py
@@ -1,10 +1,12 @@
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from messagebox.contacts import ContactStore
-from messagebox.onboarding.nfc import NfcOnboardingEngine, NfcOnboardingError
+from messagebox.onboarding.nfc import NfcOnboardingEngine, NfcOnboardingError, TonePlayer
 from messagebox.onboarding.recipients import RecipientSetup
 
 
@@ -27,6 +29,24 @@ class Clock:
 class Reader:
     def read(self):
         return None
+
+
+class TonePlayerTests(unittest.TestCase):
+    def test_uses_complete_configured_speaker_device(self):
+        calls = []
+        with tempfile.TemporaryDirectory() as directory, mock.patch.dict(
+            os.environ,
+            {"MSGBOX_SPK_DEV": "plughw:CARD=speaker,DEV=2"},
+        ):
+            player = TonePlayer(
+                directory, run=lambda *args, **kwargs: calls.append((args, kwargs))
+            )
+            player("read")
+
+        self.assertEqual(
+            calls[0][0][0][0:4],
+            ["aplay", "-q", "-D", "plughw:CARD=speaker,DEV=2"],
+        )
 
 
 def completed_recipients(root, clock):

--- a/tests/test_whatsapp_pairing.py
+++ b/tests/test_whatsapp_pairing.py
@@ -520,6 +520,7 @@ class WhatsAppFrontendAndServiceContractTests(unittest.TestCase):
         self.assertIn("Requires=messagebox-whatsapp-pairing.service", nfc_worker)
         self.assertIn("User=messagebox\n", nfc_worker)
         self.assertIn("SupplementaryGroups=messagebox i2c gpio audio", nfc_worker)
+        self.assertIn("EnvironmentFile=/etc/messagebox/env", nfc_worker)
         self.assertIn("RestrictAddressFamilies=AF_UNIX", nfc_worker)
         self.assertIn("User=root\n", completion)
         self.assertNotIn("PrivateDevices=no", web)


### PR DESCRIPTION
## Summary
- detect the lowest ALSA capture device and lowest USB playback device during fresh setup
- atomically render the existing microphone and speaker settings while preserving existing device configuration on updates
- route NFC onboarding tones through the complete configured speaker PCM

## Testing
- `make check` (222 tests)

## Physical verification still required
- fresh Raspberry Pi setup with the microphone and USB speaker connected
- reboot stability of detected ALSA card names
- recording, playback, NFC tones, microphone gain, and speaker volume