### PR TITLE
Clarify reference hardware and enclosure alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ affiliated with these retailers.
 - **Pi Zero 2 W power supply:** [official Raspberry Pi 12.5 W Micro USB Power Supply](https://www.raspberrypi.com/products/micro-usb-power-supply/)
 - **Or Pi 4B power supply:** [iUniker 5 V / 4 A USB-C supply](https://www.amazon.com/dp/B097P2NLVH)
 - **100 mm illuminated arcade button:** [Amazon](https://www.amazon.com/dp/B072JLSH34)
-- **HiLetgo PN532 NFC/RFID module kit:** [Amazon](https://www.amazon.com/dp/B01I1J17LC)
+- **NFC reader:** The original NFC build uses the [HiLetgo PN532 NFC/RFID module kit](https://www.amazon.com/dp/B01I1J17LC) and needs soldering. If you do not want to solder, use a Waveshare PN532 NFC HAT instead.
 - **Optional M2.5 screws, nuts, and washers:** [Amazon](https://www.amazon.com/dp/B0FJ1XN2XP) — useful for mounting the Pi or NFC board inside a custom enclosure; not required for a shoebox prototype
 
 You will also need:
@@ -73,10 +73,7 @@ The current reference-parts list is approximately **$150 before the enclosure,
 Zero 2 W adapters, NFC tokens, shipping, and taxes**. Retailer prices and
 availability change.
 
-This is our current reference build, not the only hardware that can work. Other
-USB speakers and microphones, and other GPIO-connected buttons, may work too.
-We encourage experimentation: treat substitutions as unvalidated, check their
-electrical and software compatibility, and share what you learn.
+This is our current reference build. Other USB speakers and microphones, and other GPIO-connected buttons, may work electrically and with the software, but each substitution is unvalidated. The printable enclosure was designed for the parts in this list. If you change the speaker, microphone, or another part, the 3D-print designs may need a revision; do not assume the substitute will fit the same case.
 
 ### What the build takes
 
@@ -126,9 +123,7 @@ or Meta.
 
 ## Step 2 — Assemble the hardware
 
-A shoebox or another sturdy, non-conductive container is enough for a first
-build. Secure the electronics, provide ventilation, and protect the cables from
-strain and loose metal.
+A shoebox or another sturdy, non-conductive box is an alternative to 3D printing the enclosure. Whichever enclosure you use, secure the electronics, provide ventilation, and protect the cables from strain and loose metal.
 
 The default public GPIO configuration is:
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -14,6 +14,8 @@
 | HiLetgo PN532 NFC/RFID V3 module kit | $9 | [Amazon](https://www.amazon.com/dp/B01I1J17LC) |
 | **Approx. total** | **$150** | |
 
+The parts above are the reference build. Other USB speakers and microphones, and other GPIO-connected buttons, may work electrically and with the software, but each substitution is unvalidated. The printable enclosure was designed for the parts in this list. If you change the speaker, microphone, or another part, the 3D-print designs may need a revision; do not assume the substitute will fit the same case.
+
 ## Enclosure
 
 The prototype Button Box enclosure has two printable parts:

--- a/hardware/enclosure/README.md
+++ b/hardware/enclosure/README.md
@@ -8,3 +8,5 @@ These STL files form the two-part prototype Button Box enclosure:
 The meshes share a 192 mm by 120 mm footprint when interpreted in millimeters.
 The top is approximately 74.5 mm tall and the bottom is approximately 20.5 mm
 tall.
+
+A shoebox or another sturdy, non-conductive box is an alternative to 3D printing these parts. Secure the electronics, provide ventilation, and protect the cables from strain and loose metal.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clarify the reference-hardware substitution limits, identify the solder-free NFC HAT alternative without adding a purchase URL, and document non-printed enclosure guidance.

## Verification

- [x] `make check` passes (222 tests).
- [x] Tests were added or updated where appropriate (documentation-only change; no test files needed).
- [x] Repository evidence and physical Pi evidence are labeled separately.
- [x] The diff contains no secrets, personal data, recordings, device state, or private URLs.
- [x] Third-party licensing and attribution were reviewed if dependencies or assets changed.
- [x] Exact-copy and three-file diff-scope checks pass.

## Physical validation

Not required; documentation-only changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ba9de7-7092-46b8-a122-3834ecc1f0cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ba9de7-7092-46b8-a122-3834ecc1f0cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

