### PR TITLE
Add Tailscale remote support provisioning

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,10 @@ not overwrite a working device without a tested backup.
 
    The Pi needs internet access during setup. See
    [Internet access for a fresh card](developer-onboarding.md#internet-access-for-a-fresh-card).
+   For an optionally shipped box that needs private, consented remote
+   maintenance, complete the [Tailscale remote-support procedure](remote-support.md)
+   while LAN access is still available. Tailscale is independent of the Button
+   Box application install and does not replace ordinary OpenSSH keys.
 4. Configure protected Wi-Fi onboarding with
    `sudo messagebox-init-wifi-onboarding`.
 5. Print the displayed box number, hotspot name, password, and setup URL for the

--- a/docs/remote-support.md
+++ b/docs/remote-support.md
@@ -1,0 +1,156 @@
+# Remote support with Tailscale
+
+Tailscale can give a shipped Button Box a private route back to its operator.
+It does not make an offline box reachable and it does not replace OpenSSH keys,
+local recovery, backups, or tested application releases.
+
+Remote support is optional. Enrolling a household box gives authorized tailnet
+members a path to its SSH service, which can expose private device state. Get
+the household's consent, restrict tailnet membership and access rules, and do
+not expose the dashboard or any service to the public internet. The Button Box
+adds no heartbeat, but the Tailscale client itself exchanges connection and
+diagnostic metadata with Tailscale's control plane; include that in the
+household's consent decision.
+
+## Provision before shipping
+
+Prepare ordinary OpenSSH access first. The administrator must be non-root,
+must have the operator's public key in `~/.ssh/authorized_keys`, and must have
+passwordless `sudo` for this unattended support model. Protect the operator's
+private key with a passphrase and keep a second authorized computer or recovery
+key available.
+
+From a clean, reviewed repository checkout on a computer that can currently
+reach the Pi over LAN or Ethernet, run:
+
+```sh
+./scripts/provision-tailscale.sh admin@message-box-001.local
+```
+
+The helper:
+
+1. Refuses root, malformed targets, and non-`message-box-*` devices.
+2. Installs Tailscale from its signed official Debian 13 repository.
+3. Opens Tailscale's interactive browser authorization when the device is not
+   already enrolled.
+4. Leaves Tailscale SSH, Serve, Funnel, subnet routing, and exit-node features
+   disabled.
+5. Holds the package so upgrades happen during an attended support session.
+
+No reusable Tailscale auth key is accepted or stored. The device joins with the
+same hostname by default. Use `--hostname NAME` only when the tailnet needs a
+different, non-sensitive device name.
+
+Keep the LAN session open. Move the operator computer to a genuinely different
+network, such as a phone hotspot, then use the address printed by the helper:
+
+```sh
+ssh admin@100.x.y.z
+```
+
+That is ordinary OpenSSH carried over Tailscale. `tailscale ssh` is deliberately
+not used, so every support computer still needs an authorized OpenSSH key.
+Confirm both the remote path and the original LAN fallback before shipping.
+
+By default, Tailscale device keys can expire and an expired remote box stops
+accepting tailnet connections. For this trusted, unattended device, open its
+entry on the **Machines** page and deliberately choose **Disable key expiry**.
+This reduces security: revoke or remove the device immediately if the box is
+lost, replaced, or no longer supported. Do not use
+`tailscale up --force-reauth` over the only remote connection.
+
+## Tailnet controls
+
+Use the Tailscale admin console to verify that the device belongs to the
+intended family-only tailnet. Give support access only to the operator accounts
+that need it, require the tailnet's normal account security, and remove stale
+devices and members promptly. Do not paste node addresses, authorization URLs,
+account names, or access-rule details into public issues or logs.
+
+Before shipping, confirm the machine is online, key expiry has the intended
+setting, Tailscale SSH is off, it advertises no routes or exit-node capability,
+and client auto-update is off. Recheck those controls after any membership or
+policy change.
+
+This repository does not install Tailscale access rules because the public code
+must not contain private tailnet identity or policy. Review those controls in
+the tailnet before shipping and after any membership change.
+
+## On-demand support
+
+The box sends no heartbeat or telemetry through this setup. During a support
+session, connect over SSH and start with bounded checks:
+
+```sh
+tailscale status --self
+messageboxctl services
+messageboxctl status
+systemctl --failed
+df -h /
+```
+
+Read only the logs needed for the incident. Before sharing output, remove phone
+numbers, WhatsApp identifiers, Wi-Fi details, NFC identifiers, recordings,
+private addresses, and authentication state.
+
+Application updates remain deliberate deployments from a reviewed commit:
+
+```sh
+git switch --detach <reviewed-commit>
+./scripts/provision.sh admin@100.x.y.z
+```
+
+Record the previously installed commit and confirm there is enough disk space
+before deploying. Do not combine a remote application update with an OS update
+unless both changes have already passed physical testing and a rollback path is
+available.
+
+For an attended Tailscale package update:
+
+```sh
+ssh admin@100.x.y.z
+sudo apt-mark unhold tailscale
+sudo apt-get update
+sudo apt-get install --only-upgrade tailscale
+sudo apt-mark hold tailscale
+tailscale version
+tailscale status --self
+```
+
+Keep the SSH session open until a second connection succeeds. Apply Raspberry
+Pi OS updates separately, in small batches, while a local helper is available.
+
+## Recovery and removal
+
+Tailscale cannot recover loss of power, failed storage, broken home internet,
+or a network change that the Pi cannot join. Before shipping, make sure someone
+at the household can:
+
+- power-cycle the box;
+- repeat phone-based Wi-Fi onboarding;
+- connect Ethernet to the router when requested.
+
+If remote access fails, try the local hostname or router address over Ethernet.
+Do not reset application data merely to repair the network.
+
+To remove remote support while connected locally:
+
+```sh
+sudo tailscale logout
+sudo systemctl disable --now tailscaled
+sudo apt-mark unhold tailscale
+sudo apt-get purge tailscale
+sudo rm -f /etc/apt/sources.list.d/tailscale.list
+sudo rm -f /usr/share/keyrings/tailscale-archive-keyring.gpg
+```
+
+Also delete or expire the device in the Tailscale admin console. Removing
+Tailscale does not remove OpenSSH keys; review `~/.ssh/authorized_keys`
+separately when transferring or retiring a box.
+
+## Tailscale references
+
+- [Linux installation](https://tailscale.com/docs/install/linux)
+- [CLI reference](https://tailscale.com/kb/1080/cli)
+- [Device key expiry](https://tailscale.com/docs/features/access-control/key-expiry)
+- [Standard SSH compared with Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh)

--- a/scripts/install/tailscale.sh
+++ b/scripts/install/tailscale.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Install Tailscale from its official Debian repository without enrolling the
+# device. Enrollment remains an explicit, interactive operator action.
+set -eu
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+[ "$(id -u)" -eq 0 ] || die "run this installer as root"
+[ -r /etc/os-release ] || die "cannot identify the operating system"
+. /etc/os-release
+
+[ "${VERSION_CODENAME:-}" = trixie ] ||
+  die "Tailscale provisioning is validated only on Debian 13 (trixie)"
+[ "$(dpkg --print-architecture)" = arm64 ] ||
+  die "Tailscale provisioning is validated only on 64-bit Raspberry Pi OS"
+case "${ID:-}" in
+  debian|raspbian) DISTRIBUTION=$ID ;;
+  *) die "Tailscale provisioning requires Debian or Raspberry Pi OS" ;;
+esac
+
+KEYRING=/usr/share/keyrings/tailscale-archive-keyring.gpg
+REPOSITORY=/etc/apt/sources.list.d/tailscale.list
+for path in "$KEYRING" "$REPOSITORY"; do
+  [ ! -L "$path" ] || die "refusing to replace symlinked $path"
+done
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl
+
+STAGING=$(mktemp -d /tmp/messagebox-tailscale.XXXXXX)
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  rm -rf -- "$STAGING"
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 1' HUP INT TERM
+
+curl --proto '=https' --tlsv1.2 -fsSL \
+  "https://pkgs.tailscale.com/stable/$DISTRIBUTION/trixie.noarmor.gpg" \
+  -o "$STAGING/tailscale-archive-keyring.gpg"
+printf '%s%s%s\n' \
+  'deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/' \
+  "$DISTRIBUTION" \
+  ' trixie main' \
+  >"$STAGING/tailscale.list"
+install -o root -g root -m 0644 \
+  "$STAGING/tailscale-archive-keyring.gpg" "$KEYRING"
+install -o root -g root -m 0644 "$STAGING/tailscale.list" "$REPOSITORY"
+
+apt-get update
+if ! dpkg-query -W -f='${Status}\n' tailscale 2>/dev/null |
+  grep -qx 'install ok installed'; then
+  apt-get install -y tailscale
+fi
+systemctl enable --now tailscaled
+
+# Shipped boxes are updated deliberately after a support check, not by an
+# unattended package run that could remove the active recovery path.
+apt-mark hold tailscale >/dev/null
+
+echo "Tailscale is installed and held for deliberate updates."

--- a/scripts/provision-tailscale.sh
+++ b/scripts/provision-tailscale.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# Install and interactively enroll a Button Box in an existing tailnet.
+# Usage: ./scripts/provision-tailscale.sh [--hostname NAME] user@host
+set -eu
+
+usage() {
+  printf '%s\n' \
+    "Usage: $0 [--hostname NAME] user@host" \
+    "Example: $0 admin@message-box-001.local" >&2
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+TAILSCALE_HOSTNAME=""
+case "$#" in
+  1)
+    TARGET=$1
+    ;;
+  3)
+    [ "$1" = --hostname ] || { usage; exit 2; }
+    TAILSCALE_HOSTNAME=$2
+    TARGET=$3
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+case "$TARGET" in
+  root@*|-*|@*|*@|*[!A-Za-z0-9._@-]*|*@*@*)
+    die "invalid non-root SSH target: $TARGET"
+    ;;
+  *@*) ;;
+  *) die "SSH target must be in user@host form" ;;
+esac
+command -v ssh >/dev/null 2>&1 || die "ssh is required"
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+INSTALLER=$SCRIPT_DIR/install/tailscale.sh
+[ -r "$INSTALLER" ] || die "missing installer: $INSTALLER"
+
+REMOTE_HOSTNAME=$(ssh -o BatchMode=yes -o ConnectTimeout=5 "$TARGET" hostname)
+case "$REMOTE_HOSTNAME" in
+  message-box-*) ;;
+  *) die "remote hostname is not a valid message-box hostname" ;;
+esac
+case "$REMOTE_HOSTNAME" in
+  *[!A-Za-z0-9-]*|*-)
+    die "remote hostname is not a valid message-box hostname"
+    ;;
+esac
+[ "${#REMOTE_HOSTNAME}" -le 63 ] ||
+  die "remote hostname is not a valid message-box hostname"
+
+if [ -z "$TAILSCALE_HOSTNAME" ]; then
+  TAILSCALE_HOSTNAME=$REMOTE_HOSTNAME
+fi
+case "$TAILSCALE_HOSTNAME" in
+  *[!A-Za-z0-9-]*|-*|*-|"") die "invalid Tailscale hostname" ;;
+esac
+[ "${#TAILSCALE_HOSTNAME}" -le 63 ] || die "invalid Tailscale hostname"
+
+ssh -o BatchMode=yes -o ConnectTimeout=5 "$TARGET" sudo -n true ||
+  die "passwordless sudo is required for remote provisioning"
+
+cat <<EOF
+
+TAILSCALE REMOTE SUPPORT
+
+Target:             $TARGET
+Remote hostname:    $REMOTE_HOSTNAME
+Tailscale hostname: $TAILSCALE_HOSTNAME
+
+This installs Tailscale from its signed official repository and may open an
+interactive authorization URL for the existing tailnet. It does not enable
+Tailscale SSH, expose the dashboard, advertise routes, or store an auth key.
+
+Continue? [y/N]
+EOF
+IFS= read -r confirmation
+case "$confirmation" in
+  y|Y|yes|YES|Yes) ;;
+  *) die "Tailscale provisioning cancelled; nothing was changed" ;;
+esac
+
+echo "Installing Tailscale on $REMOTE_HOSTNAME..."
+ssh -o BatchMode=yes "$TARGET" sudo -n /bin/sh -s <"$INSTALLER"
+
+TAILSCALE_IP=$(
+  ssh -o BatchMode=yes "$TARGET" \
+    'sudo -n tailscale ip -4 2>/dev/null || true'
+)
+if [ -z "$TAILSCALE_IP" ]; then
+  echo "Authorize $REMOTE_HOSTNAME in the browser when prompted."
+  ssh -t "$TARGET" \
+    "sudo -n tailscale up --hostname=$TAILSCALE_HOSTNAME"
+  TAILSCALE_IP=$(
+    ssh -o BatchMode=yes "$TARGET" \
+      'sudo -n tailscale ip -4 2>/dev/null || true'
+  )
+else
+  # `tailscale set` changes only the requested preference and therefore does
+  # not accidentally enable Tailscale SSH or alter existing route settings.
+  ssh -o BatchMode=yes "$TARGET" \
+    "sudo -n tailscale set --hostname=$TAILSCALE_HOSTNAME"
+fi
+
+case "$TAILSCALE_IP" in
+  ""|*[!0-9.]*) die "Tailscale did not report a valid IPv4 address" ;;
+esac
+
+SSH_USER=${TARGET%%@*}
+cat <<EOF
+
+TAILSCALE REMOTE SUPPORT READY
+
+Device: $TAILSCALE_HOSTNAME
+Address: $TAILSCALE_IP
+
+Verify from a different network:
+  ssh $SSH_USER@$TAILSCALE_IP
+
+Tailscale carries the connection; ordinary OpenSSH keys still control shell
+access. Keep the LAN connection available until that independent test passes.
+For a trusted shipped box, review and deliberately disable this device's key
+expiry in the Tailscale admin console so unattended access does not expire.
+EOF

--- a/scripts/provision-tailscale.sh
+++ b/scripts/provision-tailscale.sh
@@ -100,13 +100,13 @@ if [ -z "$TAILSCALE_IP" ]; then
   echo "Authorize $REMOTE_HOSTNAME in the browser when prompted."
   ssh -t "$TARGET" \
     "sudo -n tailscale up --hostname=$TAILSCALE_HOSTNAME"
-  TAILSCALE_IP=$(read_tailscale_ip)
-else
-  # `tailscale set` changes only the requested preference and therefore does
-  # not accidentally enable Tailscale SSH or alter existing route settings.
-  ssh -o BatchMode=yes "$TARGET" \
-    "sudo -n tailscale set --hostname=$TAILSCALE_HOSTNAME"
 fi
+
+# `tailscale set` changes only named preferences. Reassert the intentionally
+# narrow support profile on reruns without resetting the node identity.
+ssh -o BatchMode=yes "$TARGET" \
+  "sudo -n tailscale set --hostname=$TAILSCALE_HOSTNAME --auto-update=false --ssh=false --accept-routes=false --advertise-routes= --advertise-exit-node=false --exit-node= --webclient=false"
+TAILSCALE_IP=$(read_tailscale_ip)
 
 case "$TAILSCALE_IP" in
   ""|*[!0-9.]*) die "Tailscale did not report a valid IPv4 address" ;;

--- a/scripts/provision-tailscale.sh
+++ b/scripts/provision-tailscale.sh
@@ -90,18 +90,17 @@ esac
 echo "Installing Tailscale on $REMOTE_HOSTNAME..."
 ssh -o BatchMode=yes "$TARGET" sudo -n /bin/sh -s <"$INSTALLER"
 
-TAILSCALE_IP=$(
-  ssh -o BatchMode=yes "$TARGET" \
-    'sudo -n tailscale ip -4 2>/dev/null || true'
-)
+TAILSCALE_IP_COMMAND="sudo -n tailscale status --self=true --peers=false 2>/dev/null | awk 'NR == 1 && \$1 ~ /^100\\./ { print \$1 }'"
+read_tailscale_ip() {
+  ssh -o BatchMode=yes "$TARGET" "$TAILSCALE_IP_COMMAND"
+}
+
+TAILSCALE_IP=$(read_tailscale_ip)
 if [ -z "$TAILSCALE_IP" ]; then
   echo "Authorize $REMOTE_HOSTNAME in the browser when prompted."
   ssh -t "$TARGET" \
     "sudo -n tailscale up --hostname=$TAILSCALE_HOSTNAME"
-  TAILSCALE_IP=$(
-    ssh -o BatchMode=yes "$TARGET" \
-      'sudo -n tailscale ip -4 2>/dev/null || true'
-  )
+  TAILSCALE_IP=$(read_tailscale_ip)
 else
   # `tailscale set` changes only the requested preference and therefore does
   # not accidentally enable Tailscale SSH or alter existing route settings.

--- a/tests/test_tailscale_provision.py
+++ b/tests/test_tailscale_provision.py
@@ -36,7 +36,7 @@ case "$*" in
     cat >"$INSTALL_INPUT"
     [ "${INSTALL_FAIL:-0}" -eq 0 ] || exit 1
     ;;
-  *"sudo -n tailscale ip -4"*)
+  *"tailscale status --self=true --peers=false"*)
     count=0
     [ ! -f "$IP_CALLS" ] || count=$(cat "$IP_CALLS")
     count=$((count + 1))

--- a/tests/test_tailscale_provision.py
+++ b/tests/test_tailscale_provision.py
@@ -108,7 +108,10 @@ esac
         self.assertFalse(any("tailscale up" in call for call in calls), calls)
         self.assertTrue(
             any(
-                "sudo -n tailscale set --hostname=message-box-beta" in call
+                "sudo -n tailscale set --hostname=message-box-beta "
+                "--auto-update=false --ssh=false --accept-routes=false "
+                "--advertise-routes= --advertise-exit-node=false "
+                "--exit-node= --webclient=false" in call
                 for call in calls
             ),
             calls,

--- a/tests/test_tailscale_provision.py
+++ b/tests/test_tailscale_provision.py
@@ -1,0 +1,146 @@
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROVISION = ROOT / "scripts" / "provision-tailscale.sh"
+
+
+class TailscaleProvisionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.root = Path(self.temp_dir.name)
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+        self.ssh_log = self.root / "ssh.log"
+        self.install_input = self.root / "install-input.sh"
+        self.ip_calls = self.root / "ip-calls"
+        self._write_executable(
+            "ssh",
+            """#!/bin/sh
+{
+  printf 'CALL'
+  for arg in "$@"; do printf '\\t%s' "$arg"; done
+  printf '\\n'
+} >>"$SSH_LOG"
+
+case "$*" in
+  *" hostname")
+    printf '%s\\n' "${REMOTE_HOSTNAME:-message-box-001}"
+    ;;
+  *" sudo -n /bin/sh -s")
+    cat >"$INSTALL_INPUT"
+    [ "${INSTALL_FAIL:-0}" -eq 0 ] || exit 1
+    ;;
+  *"sudo -n tailscale ip -4"*)
+    count=0
+    [ ! -f "$IP_CALLS" ] || count=$(cat "$IP_CALLS")
+    count=$((count + 1))
+    printf '%s\\n' "$count" >"$IP_CALLS"
+    if [ "${ALREADY_CONNECTED:-0}" -eq 1 ] || [ "$count" -gt 1 ]; then
+      printf '%s\\n' 100.100.100.100
+    fi
+    ;;
+esac
+""",
+        )
+
+    def _write_executable(self, name, content):
+        path = self.bin_dir / name
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+
+    def _run(self, *arguments, confirmation="yes\n", **extra_env):
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin_dir}:{env['PATH']}",
+                "SSH_LOG": str(self.ssh_log),
+                "INSTALL_INPUT": str(self.install_input),
+                "IP_CALLS": str(self.ip_calls),
+                **extra_env,
+            }
+        )
+        return subprocess.run(
+            [str(PROVISION), *arguments],
+            cwd=self.root,
+            env=env,
+            input=confirmation,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_installs_and_uses_interactive_browser_enrollment(self):
+        result = self._run("admin@message-box-001.local")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.ssh_log.read_text(encoding="utf-8").splitlines()
+        self.assertTrue(
+            any(
+                "\t-t\tadmin@message-box-001.local\t"
+                "sudo -n tailscale up --hostname=message-box-001" in call
+                for call in calls
+            ),
+            calls,
+        )
+        installer = self.install_input.read_text(encoding="utf-8")
+        self.assertIn("https://pkgs.tailscale.com/stable/", installer)
+        self.assertIn("debian|raspbian", installer)
+        self.assertNotIn("auth-key", installer.lower())
+        self.assertNotIn("--ssh", installer)
+        self.assertIn("ssh admin@100.100.100.100", result.stdout)
+
+    def test_existing_enrollment_does_not_run_tailscale_up(self):
+        result = self._run(
+            "--hostname",
+            "message-box-beta",
+            "admin@message-box-001.local",
+            ALREADY_CONNECTED="1",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self.ssh_log.read_text(encoding="utf-8").splitlines()
+        self.assertFalse(any("tailscale up" in call for call in calls), calls)
+        self.assertTrue(
+            any(
+                "sudo -n tailscale set --hostname=message-box-beta" in call
+                for call in calls
+            ),
+            calls,
+        )
+        self.assertIn("Device: message-box-beta", result.stdout)
+
+    def test_rejects_unsafe_target_before_running_ssh(self):
+        result = self._run("-oProxyCommand=bad")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("invalid non-root SSH target", result.stderr)
+        self.assertFalse(self.ssh_log.exists())
+
+    def test_cancellation_makes_no_remote_changes(self):
+        result = self._run(
+            "admin@message-box-001.local", confirmation="no\n"
+        )
+
+        self.assertEqual(result.returncode, 1)
+        calls = self.ssh_log.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(calls), 2, calls)
+        self.assertFalse(self.install_input.exists())
+
+    def test_install_failure_does_not_attempt_enrollment(self):
+        result = self._run(
+            "admin@message-box-001.local", INSTALL_FAIL="1"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        calls = self.ssh_log.read_text(encoding="utf-8").splitlines()
+        self.assertFalse(any("tailscale up" in call for call in calls), calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a target-validating host-side helper for installing and interactively enrolling a Button Box in Tailscale
- install from the signed official Debian/Raspberry Pi OS 13 repository without accepting or storing an auth key
- preserve ordinary OpenSSH authentication and leave Tailscale SSH, Serve, Funnel, routing, exit-node, dashboard exposure, and auto-update disabled
- document household consent, tailnet controls, key expiry, on-demand diagnostics, deliberate upgrades, recovery, and removal

This is intentionally based directly on public `main` and is independent of #14. Merging it does not imply that #14 has passed physical acceptance.

## Validation

- [x] `make check`
- [x] 227 unit tests, including first enrollment, rerun/idempotency, cancellation, unsafe-target rejection, and install-failure boundaries
- [x] Ruff, ShellCheck, Biome, Python and shell syntax
- [x] `git diff --check`
- [x] focused scan contains no auth keys, tailnet identity, household data, or real device addresses

## Physical validation still required

- [ ] install and enroll the Raspberry Pi 4B while LAN SSH remains open
- [ ] verify ordinary OpenSSH over Tailscale from a genuinely different network
- [ ] verify LAN SSH remains available
- [ ] confirm in the admin console: intended family tailnet, least-privilege access, Tailscale SSH off, no advertised routes/exit node, auto-update off, and deliberate key-expiry setting
- [ ] reboot and repeat the remote SSH check
- [ ] exercise Ethernet/power-cycle/Wi-Fi recovery with the local helper

Do not deploy this to the shipped-device candidate until the reviewed commit and rollback checklist are agreed.