### PR TITLE
Swap WhatsApp community invite URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ approved person or group. Incoming replies wait on the box until the child
 presses the button to listen.
 
 [Visit button.box](https://button.box/) ·
-[Join the WhatsApp community](https://chat.whatsapp.com/KkVOY76T0go1J6lGElwQJg?mode=gi_t) ·
+[Join the WhatsApp community](https://chat.whatsapp.com/FJ8LYL79k8zEMfoiyPjLPb?mode=gi_t) ·
 [Report an issue](https://github.com/button-box/button-box/issues)
 
 
@@ -487,7 +487,7 @@ Before updating a working physical box:
 
 Use [GitHub Issues](https://github.com/button-box/button-box/issues) for
 reproducible bugs and documentation problems, or
-[join the community](https://chat.whatsapp.com/KkVOY76T0go1J6lGElwQJg?mode=gi_t)
+[join the community](https://chat.whatsapp.com/FJ8LYL79k8zEMfoiyPjLPb?mode=gi_t)
 for builder discussion.
 
 A useful issue includes:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replace the locked WhatsApp community invite URL with the new invite. String replace only in `README.md` (header community link and Get help community link). Surrounding copy is unchanged. `?mode=gi_t` is kept.

OLD: `https://chat.whatsapp.com/KkVOY76T0go1J6lGElwQJg?mode=gi_t`
NEW: `https://chat.whatsapp.com/FJ8LYL79k8zEMfoiyPjLPb?mode=gi_t`

## Verification

- [x] Grep of the old invite URL is empty across the repo.
- [x] Grep of the new invite URL shows the two README community links.
- [ ] `make check` is not required for this docs-only string replace.
- [x] Tests were not added (no behavior change).
- [x] Repository evidence and physical Pi evidence are labeled separately.
- [x] The diff contains no secrets, personal data, recordings, device state, or private URLs.
- [x] Third-party licensing and attribution were reviewed if dependencies or assets changed.

## Physical validation

not required

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdc4689b-16e8-487f-8a0e-f377a26d7b03?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc4689b-16e8-487f-8a0e-f377a26d7b03&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

