### PR TITLE
Fix shared settings lock ownership

### DIFF
--- a/messagebox/settings.py
+++ b/messagebox/settings.py
@@ -170,6 +170,24 @@ def _atomic_json(path, document):
             temporary.unlink(missing_ok=True)
 
 
+def _open_shared_lock(path):
+    """Set the shared mode only while we own a newly created lock."""
+    while True:
+        try:
+            lock = open(path, "x+b")
+        except FileExistsError:
+            try:
+                return open(path, "r+b")
+            except FileNotFoundError:
+                continue
+        try:
+            os.fchmod(lock.fileno(), 0o660)
+        except OSError:
+            lock.close()
+            raise
+        return lock
+
+
 class SettingsStore:
     def __init__(self, path=SETTINGS_FILE, *, environ=None):
         self.path = Path(path)
@@ -208,8 +226,7 @@ class SettingsStore:
         if set(candidate) != value_keys:
             raise SettingsError("settings request has an invalid schema")
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.lock_path, "a+b") as lock:
-            os.fchmod(lock.fileno(), 0o660)
+        with _open_shared_lock(self.lock_path) as lock:
             fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
             try:
                 current, _warning = self.load()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,9 @@
+import os
+import stat
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from messagebox.settings import RevisionConflict, SettingsError, SettingsStore, defaults
 
@@ -56,6 +59,39 @@ class SettingsStoreTests(unittest.TestCase):
         current, _warning = store.load()
         self.assertEqual(current, saved)
         self.assertEqual(current["max_recording_seconds"], 30)
+
+    def test_existing_shared_lock_does_not_require_file_ownership(self):
+        store = SettingsStore(self.path, environ={"TZ": "UTC"})
+        initial, _warning = store.load()
+        store.lock_path.write_bytes(b"")
+        store.lock_path.chmod(0o660)
+        lock_inode = store.lock_path.stat().st_ino
+        real_fchmod = os.fchmod
+
+        def reject_owner_only_lock_change(descriptor, mode):
+            if os.fstat(descriptor).st_ino == lock_inode:
+                raise PermissionError(1, "Operation not permitted")
+            return real_fchmod(descriptor, mode)
+
+        with mock.patch(
+            "messagebox.settings.os.fchmod",
+            side_effect=reject_owner_only_lock_change,
+        ):
+            saved = store.update(self.candidate(initial, master_volume_percent=70), 0)
+
+        self.assertEqual(saved["revision"], 1)
+        self.assertEqual(saved["master_volume_percent"], 70)
+
+    def test_new_lock_is_group_writable_under_restrictive_umask(self):
+        store = SettingsStore(self.path, environ={"TZ": "UTC"})
+        initial, _warning = store.load()
+        previous_umask = os.umask(0o077)
+        try:
+            store.update(self.candidate(initial, master_volume_percent=70), 0)
+        finally:
+            os.umask(previous_umask)
+
+        self.assertEqual(stat.S_IMODE(store.lock_path.stat().st_mode), 0o660)
 
     def test_corrupt_primary_uses_last_valid_snapshot_and_attention(self):
         store = SettingsStore(self.path, environ={"TZ": "UTC"})


### PR DESCRIPTION
## Outcome

Allow the runtime dashboard to save settings when the shared settings lock was originally created by the onboarding service under a different Unix user.

## Root cause

Every settings update called `fchmod(0660)` on the lock file. Group membership allowed the runtime service to open and lock the file, but only the file owner could change its mode, so cross-user saves failed with `[Errno 1] Operation not permitted`.

## Implementation

- Create the lock file exclusively when it does not exist.
- Set mode `0660` only while the current process owns that newly created file.
- Open an existing group-writable lock without attempting to change its metadata.
- Retry if the lock disappears between existence detection and open.

Locking, revision checks, settings validation, and atomic writes are unchanged.

## Validation

- Added a regression test that reproduces the ownership failure and confirms an existing shared lock does not require `fchmod`.
- Added coverage confirming a newly created lock is `0660` even under a restrictive umask.
- `make check` passes: lint, formatting, shell checks, and 277 unit tests.
- `git diff --check` passes.

## Deployment and rollback

This PR has not been deployed to a device. After review, physical acceptance is saving a dashboard setting after the onboarding-to-runtime service-user transition. Rollback is reverting this commit.

## Non-goals

No changes to the settings schema, recipients, WhatsApp, NFC, Wi-Fi, systemd configuration, or device data.