### PR TITLE
Fix healthy Wi-Fi changes falling back to setup hotspot

### DIFF
--- a/messagebox/onboarding/connectivity.py
+++ b/messagebox/onboarding/connectivity.py
@@ -18,6 +18,9 @@ PROOF_ADDRESS = "wlan0_ipv4"
 PROOF_ROUTE = "wlan0_default_route"
 PROOF_DNS = "approved_dns"
 PROOF_HTTPS = "wlan0_https_204"
+PROOFS = frozenset(
+    {PROOF_NM, PROOF_MODE, PROOF_ADDRESS, PROOF_ROUTE, PROOF_DNS, PROOF_HTTPS}
+)
 
 
 class ConnectivityChecker:

--- a/messagebox/onboarding/state.py
+++ b/messagebox/onboarding/state.py
@@ -12,6 +12,8 @@ import time
 from contextlib import contextmanager
 from pathlib import Path
 
+from messagebox.onboarding.connectivity import PROOFS
+
 
 VERSION = 1
 
@@ -43,16 +45,6 @@ SAFE_ERRORS = frozenset(
         "DNS_FAILED",
         "HTTPS_204_FAILED",
         "CHECK_COMMAND_FAILED",
-    }
-)
-PROOFS = frozenset(
-    {
-        "wlan0_nm_active",
-        "wlan0_non_ap",
-        "wlan0_ipv4",
-        "wlan0_default_route",
-        "approved_dns",
-        "wlan0_https_204",
     }
 )
 WHATSAPP_PROOFS = frozenset(

--- a/messagebox/wifi_change.py
+++ b/messagebox/wifi_change.py
@@ -10,21 +10,13 @@ import time
 import unicodedata
 from pathlib import Path
 
-from messagebox.onboarding.connectivity import ConnectivityChecker
+from messagebox.onboarding.connectivity import PROOFS, ConnectivityChecker
 from messagebox.onboarding.reset import perform_reset
 from messagebox.runtime_paths import SETTINGS_DIR
 
 
 REQUEST_FILE = SETTINGS_DIR / "wifi-change.json"
 STATUS_FILE = SETTINGS_DIR / "wifi-change-status.json"
-PROOFS = {
-    "wlan0_nm_active",
-    "wlan0_non_ap",
-    "wlan0_ipv4",
-    "wlan0_default_route",
-    "wlan0_dns",
-    "wlan0_https",
-}
 
 
 class WifiChangeError(ValueError):

--- a/tests/test_wifi_change.py
+++ b/tests/test_wifi_change.py
@@ -2,21 +2,16 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from messagebox.wifi_change import PROOFS, execute_change, load_status, request_change
-
-
-class Checker:
-    def __init__(self, *results):
-        self.results = iter(results)
-
-    def check(self):
-        return next(self.results)
+from messagebox.onboarding.connectivity import ConnectivityChecker
+from messagebox.wifi_change import execute_change, load_status, request_change
 
 
 class Runner:
-    def __init__(self, uuids):
+    def __init__(self, uuids, https_codes=("204",)):
         self.uuids = iter(uuids)
+        self.https_codes = iter(https_codes)
         self.calls = []
 
     def __call__(self, command, **kwargs):
@@ -24,6 +19,18 @@ class Runner:
         stdout = ""
         if "GENERAL.CON-UUID" in command:
             stdout = next(self.uuids) + "\n"
+        elif "GENERAL.STATE,GENERAL.TYPE" in command:
+            stdout = "GENERAL.STATE:100 (connected)\nGENERAL.TYPE:wifi\n"
+        elif command[0] == "iw":
+            stdout = "Interface wlan0\n\ttype managed\n"
+        elif command[:3] == ["ip", "-4", "-o"]:
+            stdout = "2: wlan0 inet 192.0.2.8/24 scope global wlan0\n"
+        elif command[0] == "ip":
+            stdout = "default via 192.0.2.1 dev wlan0\n"
+        elif command[0] == "getent":
+            stdout = "192.0.2.10 STREAM connectivitycheck.gstatic.com\n"
+        elif command[0] == "curl":
+            stdout = next(self.https_codes)
         return subprocess.CompletedProcess(command, 0, stdout, "")
 
 
@@ -46,34 +53,35 @@ class WifiChangeTests(unittest.TestCase):
     def test_success_keeps_password_out_of_arguments_and_deletes_old_only_after_proof(self):
         self.submit()
         runner = Runner(["1111-aaaa", "2222-bbbb"])
+        fallback = mock.Mock()
         outcome = execute_change(
             request_path=self.request,
             status_path=self.status,
             runner=runner,
-            checker=Checker({"ok": True, "proof": sorted(PROOFS)}),
+            checker=ConnectivityChecker(command_runner=runner, attempts=1),
+            fallback=fallback,
             clock=lambda: 1000,
         )
         self.assertEqual(outcome, "connected")
+        fallback.assert_not_called()
         commands = [command for command, _kwargs in runner.calls]
         self.assertNotIn("private-password", " ".join(" ".join(command) for command in commands))
         connect = next(call for call in runner.calls if "connect" in call[0])
         self.assertEqual(connect[1]["input"], "private-password\n")
         self.assertEqual(commands[-1], ["nmcli", "connection", "delete", "uuid", "1111-aaaa"])
+        self.assertEqual(commands[-2][0], "curl")
         self.assertEqual(load_status(self.status)["status"], "connected")
         self.assertFalse(self.request.exists())
 
     def test_failed_candidate_rolls_back_old_profile_without_hotspot(self):
         self.submit()
-        runner = Runner(["1111-aaaa", "2222-bbbb"])
+        runner = Runner(["1111-aaaa", "2222-bbbb"], https_codes=("200", "204"))
         fallback_calls = []
         outcome = execute_change(
             request_path=self.request,
             status_path=self.status,
             runner=runner,
-            checker=Checker(
-                {"ok": False, "proof": []},
-                {"ok": True, "proof": sorted(PROOFS)},
-            ),
+            checker=ConnectivityChecker(command_runner=runner, attempts=1),
             fallback=lambda **kwargs: fallback_calls.append(kwargs),
             clock=lambda: 1000,
         )
@@ -85,19 +93,19 @@ class WifiChangeTests(unittest.TestCase):
             commands,
         )
         self.assertEqual(load_status(self.status)["status"], "rolled_back")
+        self.assertNotIn(["nmcli", "connection", "delete", "uuid", "1111-aaaa"], commands)
+        self.assertEqual(commands[-1], ["nmcli", "connection", "delete", "uuid", "2222-bbbb"])
+        self.assertEqual(commands[-2][0], "curl")
 
     def test_failed_candidate_and_rollback_reopen_hotspot_without_enabling_units(self):
         self.submit()
-        runner = Runner(["1111-aaaa", "2222-bbbb"])
+        runner = Runner(["1111-aaaa", "2222-bbbb"], https_codes=("200", "200"))
         fallback_calls = []
         outcome = execute_change(
             request_path=self.request,
             status_path=self.status,
             runner=runner,
-            checker=Checker(
-                {"ok": False, "proof": []},
-                {"ok": False, "proof": []},
-            ),
+            checker=ConnectivityChecker(command_runner=runner, attempts=1),
             fallback=lambda **kwargs: fallback_calls.append(kwargs),
             clock=lambda: 1000,
         )


### PR DESCRIPTION
## Summary

Changing Wi-Fi through the dashboard rejects a healthy connection because the transaction expects `wlan0_dns` and `wlan0_https`, while the connectivity checker returns `approved_dns` and `wlan0_https_204`. The same mismatch rejects a healthy rollback and unnecessarily reopens the setup hotspot.

Define the complete proof set beside the checker's proof constants and reuse it in both runtime Wi-Fi changes and onboarding state. Upgrade the transaction tests to run the real checker against simulated command responses, covering successful connection, successful rollback, and recovery when both networks fail. Keep the existing strict proof validation and password handling.

## Verification

- [x] `make check` passes: 277 tests plus configured syntax and lint checks.
- [x] Regression tests fail on the original code for healthy connection and rollback, then pass with this fix.
- [x] Tests verify the old profile is retained through rollback and profile deletion follows the final connectivity check.
- [x] `git diff --check` passes.
- [x] Repository evidence and physical Pi evidence are labeled separately.
- [x] The diff contains only source and synthetic tests; no credentials, private device state or recordings.
- No dependency, asset, installation-path or persisted proof-name changes.

## Physical validation

Not performed. Before deployment, verify a dashboard Wi-Fi change to a working network and a failed candidate with successful rollback on a Raspberry Pi. This PR does not deploy or modify a device.
